### PR TITLE
Fix issues for procedures with side effects and sym vs. ident

### DIFF
--- a/src/tests/basic.nim
+++ b/src/tests/basic.nim
@@ -21,7 +21,7 @@ proc testBasic() =
     just aInner:
       assert aInner == 10, "Value in 'a' should be 10"
       assert a.valid, "'a' should only be valid in this clause"
-      aInner = 15
+      a = maybe.just(15)
 
     nothing:
       assert false, "This clause should be unreachable" 


### PR DESCRIPTION
This creates a temporary symbol for the result of the maybe, so a procedure with side effects can be passed in as the first argument. And replaces the `replaceIdents` logic with simply creating a variable in the scope that takes the value of the maybe making it slightly more robust. It also fixes the slight issue where symbols would not work as the `just` and `nothing` keyword, something which apparently get's passed in sometimes.